### PR TITLE
Sign the Dangerzone 0.4.1 rpms

### DIFF
--- a/dangerzone/f38/dangerzone-0.4.1-1.noarch.rpm
+++ b/dangerzone/f38/dangerzone-0.4.1-1.noarch.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1daeef6a68857fe5d6d10fad06f82f711c4f6ed0c395514102438d3f815eb350
+oid sha256:59a779a8cc55ba5778d6582a1cc8a9493c3fb906fa07a170d5a27f7114ee2917
 size 708341322

--- a/dangerzone/f38/dangerzone-0.4.1-1.src.rpm
+++ b/dangerzone/f38/dangerzone-0.4.1-1.src.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c841543fa6c86d231cc06c6674d1c09b1aec3063529e86da5af70481056ff76
+oid sha256:9a5da18bc6c1f3556d4352048b999b1b5c823de99b9084495f1ffc49a5c0b8ce
 size 711966669


### PR DESCRIPTION
The previously added rpms were not signed at all. Amend this by signing the rpms with the proper key.