### PR TITLE
Improve RPM signature verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ jobs:
           name: Verify signatures on all RPMs
           command: |
             git lfs install && git lfs pull
-            rpm --import fpf-yum-tools-archive-keyring.gpg
-            for i in dangerzone/*/*.rpm; do rpm --checksig "$i"; done
+            gpg --import fpf-yum-tools-archive-keyring.gpg
+            ./scripts/publish.py --verify --all
 workflows:
   check-packages:
     jobs:

--- a/scripts/publish.py
+++ b/scripts/publish.py
@@ -53,6 +53,8 @@ def verify_sig_rpm(path, key_id):
 def verify_all_rpms(key_id):
     for root, dirs, files in os.walk(RPM_DIR):
         for name in files:
+            if not name.endswith(".rpm"):
+                continue
             path = os.path.join(root, name)
             verify_sig_rpm(path, key_id)
 


### PR DESCRIPTION
Update our publish script to properly check for RPM signatures. Then, use this script in our CircleCI config to perform a better signature verification, since the `rpm --checksig` command does not properly verify unsigned packages.