### PR TITLE
Publish Dangerzone 0.5.0 RPMs

### DIFF
--- a/dangerzone/f37/dangerzone-0.4.2-1.noarch.rpm
+++ b/dangerzone/f37/dangerzone-0.4.2-1.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c384100d5edeb41fe5816f8b50f25a1fe9bb5ca02cf88fd975cf76ffdcdb1108
-size 944597879

--- a/dangerzone/f37/dangerzone-0.4.2-1.src.rpm
+++ b/dangerzone/f37/dangerzone-0.4.2-1.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e33bd76a39cc81e617e22a6be42fdf10cd2b6a628cb3b7307418fec3ea9f1706
-size 949616941

--- a/dangerzone/f37/dangerzone-0.5.0-1.fc37.src.rpm
+++ b/dangerzone/f37/dangerzone-0.5.0-1.fc37.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c813126f5bacaa1934e28e1b3b9cf157d4d0a8a52ff77f86ee6d835c20c81748
+size 646095829

--- a/dangerzone/f37/dangerzone-0.5.0-1.fc37.x86_64.rpm
+++ b/dangerzone/f37/dangerzone-0.5.0-1.fc37.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:989c14dee149fad33e39b891297f53fb2d0c16aa3ae253f122f8fef43c0f1033
+size 641593789

--- a/dangerzone/f37/dangerzone-qubes-0.5.0-1.fc37.src.rpm
+++ b/dangerzone/f37/dangerzone-qubes-0.5.0-1.fc37.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f73045162501a45fbd0d1fb080a827285f94c63e48dc14df05fe115a83bb5257
+size 145205

--- a/dangerzone/f37/dangerzone-qubes-0.5.0-1.fc37.x86_64.rpm
+++ b/dangerzone/f37/dangerzone-qubes-0.5.0-1.fc37.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:488f259003451fae481071557b8bc64cf826e8149fd35455be411b173e299138
+size 210358

--- a/dangerzone/f38/dangerzone-0.4.2-1.noarch.rpm
+++ b/dangerzone/f38/dangerzone-0.4.2-1.noarch.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:29cef11223d7c98f5162d2cc65078b6b300f8347e29f2ab6c43d3fa09b75eeee
-size 944597973

--- a/dangerzone/f38/dangerzone-0.4.2-1.src.rpm
+++ b/dangerzone/f38/dangerzone-0.4.2-1.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efd77f2c2e60b65ed8b0f8277d25b58291a46c1bce38f9ba19fac7ae9ee0ac97
-size 949616956

--- a/dangerzone/f38/dangerzone-0.5.0-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-0.5.0-1.fc38.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e28bd02fd738d93580eab268332ba362f68cade618ec2deb7c667d0f2a45de7
+size 646095968

--- a/dangerzone/f38/dangerzone-0.5.0-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-0.5.0-1.fc38.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e998897d570e0cd8379251f727679d22d9a963563e0bd3f98bbab1f7851561c2
+size 641591975

--- a/dangerzone/f38/dangerzone-qubes-0.5.0-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.5.0-1.fc38.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d0c72dfc445f261ee7691df18cb84778bce457eb6e9ec6a4d3a2ab1c6b24276
+size 145343

--- a/dangerzone/f38/dangerzone-qubes-0.5.0-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.5.0-1.fc38.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1b72d99e11235365595d79c81acdde2aafb1c60072226460f16f2aaafe524a8
+size 210411


### PR DESCRIPTION
Replace the Dangerzone 0.4.2 RPMs with the newer 0.5.0 RPMs. Also, add RPMs built for Qubes OS, for Fedora 37/38 templates.