### PR TITLE
Add PySide6 6.6.1 RPM for Fedora 39

### DIFF
--- a/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.src.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccd75fd3318a8c852c2541370c4dc7e8992bd9e40d023cb788183cc08f55ba36
+size 206260254

--- a/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ca1b5fd5f029842e6229412faf0781ac00bf7b1f864ebde3ce69a515bd817df
+size 118936246


### PR DESCRIPTION
Add PySide6 RPM created from the apyrgio/python3-pyside6-rpm repo, based on 6.6.1. This RPM has been added only to the Fedora 39 repo, for testing purposes. If tests are successful, it will be backported to the Fedora 38 repo.