### PR TITLE
Add PySide6 6.6.2 RPM for Fedora 39

### DIFF
--- a/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.src.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccd75fd3318a8c852c2541370c4dc7e8992bd9e40d023cb788183cc08f55ba36
-size 206260254

--- a/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.1-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ca1b5fd5f029842e6229412faf0781ac00bf7b1f864ebde3ce69a515bd817df
-size 118936246

--- a/dangerzone/f39/python3-pyside6-6.6.2-1.fc39.src.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.2-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b963e3e83f7e0b1e75b7188af1c31c5a7266422ea806e666fa0ceef4dd4e2161
+size 207272070

--- a/dangerzone/f39/python3-pyside6-6.6.2-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.2-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1b22a5b5b46c73783a7c57f6fc6791f9c59aedc9a9127192fcdd42a0b76a90f
+size 118842969


### PR DESCRIPTION
Add PySide6 RPM created from the freedomofpress/maint-dangerzone-pyside6 repo, based on 6.6.2.

This RPM has been added only to the Fedora 39 repo, because we decided that Fedora 38 will still use PySide2.