### PR TITLE
Fix dangerzone-qubes package for Fedora 38

### DIFF
--- a/dangerzone/f38/dangerzone-qubes-0.6.0-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.0-1.fc38.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b86cdf21fd33af01849357921a33f5aa679a7070fc64cef18ecc4300596daddd
-size 150935

--- a/dangerzone/f38/dangerzone-qubes-0.6.0-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.0-1.fc38.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77f62de4abe43dbd81b90357e6f8bd857604f9abcf97547e36e3c0ee07110f50
-size 209642

--- a/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bf90f33c39e1d6b58ea70555082585335abef709c2910f3762fc2539a9a9d8e
+size 151299

--- a/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5185af288083f823b5fcfaf4db10b25670e9d84be8ddba3459f21d5b7fb9b0e8
+size 209956


### PR DESCRIPTION
The Fedora 38 build for `dangerzone-qubes` had a bug in the OCR phase. Publish a new dangerzone-qubes RPM that fixes it, with a bump in the release number from 1 to 2, so that end-users can get upgraded.

Refs freedomofpress/dangerzone#737