### PR TITLE
Publish Dangerzone 0.6.1 RPMs

### DIFF
--- a/dangerzone/f38/dangerzone-0.6.0-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-0.6.0-1.fc38.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8996922f6ec0e41778d7b01d9c11708690e5cfe8287212e54a07d395245448a
-size 628754020

--- a/dangerzone/f38/dangerzone-0.6.0-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-0.6.0-1.fc38.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6680554da844b74a0cde0fd8b076ffe4ba52b96cecd3207d36bf87bfeaaddacb
-size 625540586

--- a/dangerzone/f38/dangerzone-0.6.1-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-0.6.1-1.fc38.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:530ba7f1b6536eea6c852fb50c9fd972fb527adf50966f59b0d2cea503c88a55
+size 635641401

--- a/dangerzone/f38/dangerzone-0.6.1-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-0.6.1-1.fc38.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fef30f0edfeefd71c2bbd8aa50e2754e18446e84ea50bb76705647a0be3ba37
+size 632457991

--- a/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bf90f33c39e1d6b58ea70555082585335abef709c2910f3762fc2539a9a9d8e
-size 151299

--- a/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.0-2.fc38.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5185af288083f823b5fcfaf4db10b25670e9d84be8ddba3459f21d5b7fb9b0e8
-size 209956

--- a/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3ff3346bbea5748c9be208efd0b0f35fa2ab7a9ab0e5a8faac159737ac06b38
+size 226878

--- a/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b04ae5b6adbc7aa4c6c6149c2d930669ec71b3547dd51a3ae21315eee775209a
+size 216062

--- a/dangerzone/f39/dangerzone-0.6.0-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-0.6.0-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee91c6b88f17d19a4661d00532ea0fd8634ec83613f5dac28516d5cc34ea8dd6
-size 628754297

--- a/dangerzone/f39/dangerzone-0.6.0-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-0.6.0-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7020bdcd7100bb15f428b6baee4041d3635b5dd0db8fc177df94a0ee9d742d3
-size 625536922

--- a/dangerzone/f39/dangerzone-0.6.1-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-0.6.1-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb6fa0edc12fb9c617e3775eecdb201bde6f83e6a6d58773ecb3e28c919b07da
+size 635641669

--- a/dangerzone/f39/dangerzone-0.6.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-0.6.1-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:479425a99802c09d2a80f6654e683210a43dc198daf10e6f400d36ceb8a4755d
+size 632380449

--- a/dangerzone/f39/dangerzone-qubes-0.6.0-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.0-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c41cc64226f362ddc5650456c30ef6d8e3de182e44795ff8f59390d53541d61e
-size 151204

--- a/dangerzone/f39/dangerzone-qubes-0.6.0-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.0-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:620b54e2a2b10269776c56aa7271635abd8375269e3551c702e3d17baee58d89
-size 207859

--- a/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a762697c547079f3e1311ca14413237740453a0939e86689097306bdf42bd0f3
+size 227151

--- a/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea1eaed030a6ad23e2ba11f9081d700d18d286aadafd55d81c8666bd37c86cfb
+size 214007

--- a/dangerzone/f40/dangerzone-0.6.1-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.6.1-1.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:898bb8fe9a1b9ce5568241de5d70a304b11e452689c57e949d8343b86ca80907
+size 635636640

--- a/dangerzone/f40/dangerzone-0.6.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.6.1-1.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20b9626b82d11b4393ed3639065cba92649294bb5cc1d530ed0c83eaf815d3b5
+size 632380008

--- a/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd647521b5521c4842349eb4f75fb5fa6e302bb6add9b642a14d70cb9fe95028
+size 227208

--- a/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a1cd22b67ec4b4188b2a4472de93d058e3cb125b3d2e7a5d6751dd4cb29ab72
+size 214044


### PR DESCRIPTION
Replace the Dangerzone 0.6.0 RPMs with newer 0.6.1 RPMs.