### PR TITLE
Add PySide6 6.7.1 RPMs for Fedora 39/40

### DIFF
--- a/dangerzone/f38/dangerzone-0.6.1-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-0.6.1-1.fc38.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:530ba7f1b6536eea6c852fb50c9fd972fb527adf50966f59b0d2cea503c88a55
-size 635641401

--- a/dangerzone/f38/dangerzone-0.6.1-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-0.6.1-1.fc38.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fef30f0edfeefd71c2bbd8aa50e2754e18446e84ea50bb76705647a0be3ba37
-size 632457991

--- a/dangerzone/f38/dangerzone-0.6.1-2.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-0.6.1-2.fc38.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51d6623f9c7c17f3b01c6de78264ef1abcb006434665cbf837a5d1f1c8cf92b8
+size 635567499

--- a/dangerzone/f38/dangerzone-0.6.1-2.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-0.6.1-2.fc38.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab24da9cb6a562875205c6bf4d8e32a942788582edf537ee9b88ae4205904f73
+size 632458283

--- a/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3ff3346bbea5748c9be208efd0b0f35fa2ab7a9ab0e5a8faac159737ac06b38
-size 226878

--- a/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.1-1.fc38.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b04ae5b6adbc7aa4c6c6149c2d930669ec71b3547dd51a3ae21315eee775209a
-size 216062

--- a/dangerzone/f38/dangerzone-qubes-0.6.1-2.fc38.src.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.1-2.fc38.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce3d582544e7db96ffeb685051122dac2dee0345e56fc20cf23a6c983acf989c
+size 153671

--- a/dangerzone/f38/dangerzone-qubes-0.6.1-2.fc38.x86_64.rpm
+++ b/dangerzone/f38/dangerzone-qubes-0.6.1-2.fc38.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06a41c8607c17d4475137fdaa86c12688e47f14b5adeacd5bc156b035de9ff28
+size 216389

--- a/dangerzone/f39/dangerzone-0.6.1-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-0.6.1-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb6fa0edc12fb9c617e3775eecdb201bde6f83e6a6d58773ecb3e28c919b07da
-size 635641669

--- a/dangerzone/f39/dangerzone-0.6.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-0.6.1-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:479425a99802c09d2a80f6654e683210a43dc198daf10e6f400d36ceb8a4755d
-size 632380449

--- a/dangerzone/f39/dangerzone-0.6.1-2.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-0.6.1-2.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0d6a06646bae34d542cf8753ad4b641d245142668e3b77266a89902542b5290
+size 635567738

--- a/dangerzone/f39/dangerzone-0.6.1-2.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-0.6.1-2.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3103ba0d5875e8c8c4723b46c3cc753f9b7cb7c4ce917d6c0e2dd96aded88b6e
+size 632382116

--- a/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a762697c547079f3e1311ca14413237740453a0939e86689097306bdf42bd0f3
-size 227151

--- a/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.1-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea1eaed030a6ad23e2ba11f9081d700d18d286aadafd55d81c8666bd37c86cfb
-size 214007

--- a/dangerzone/f39/dangerzone-qubes-0.6.1-2.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.1-2.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1733a0e0463a9ed4feb488409e5355dc0e1f3e94865ccefb1be23ceb220add0
+size 153911

--- a/dangerzone/f39/dangerzone-qubes-0.6.1-2.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.6.1-2.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8052275cc36bb6b7583db3fa902f9cf047da342dd331a3f6f4ac3d8ae25ef15c
+size 214479

--- a/dangerzone/f39/python3-pyside6-6.6.3.1-1.fc39.src.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.3.1-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34082ad2a67077ede2b372d1e9a234e8b829a515ec6028f6ea7513fc95be1928
-size 207528257

--- a/dangerzone/f39/python3-pyside6-6.6.3.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/python3-pyside6-6.6.3.1-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6947a0512ecbab44d24e1398f9baa1fce3effa4828587add0fc297f8effbfb44
-size 120529492

--- a/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.src.rpm
+++ b/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85792245e5b648078915544f61cbd35764b5f4c41bee9603ba2400f0753c8534
+size 224162989

--- a/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65f6a4874df15b8b592ef4c61934a9ae4aab6de863c00dc7d39cae02f8ba7710
+size 133492668

--- a/dangerzone/f40/dangerzone-0.6.1-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.6.1-1.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:898bb8fe9a1b9ce5568241de5d70a304b11e452689c57e949d8343b86ca80907
-size 635636640

--- a/dangerzone/f40/dangerzone-0.6.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.6.1-1.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20b9626b82d11b4393ed3639065cba92649294bb5cc1d530ed0c83eaf815d3b5
-size 632380008

--- a/dangerzone/f40/dangerzone-0.6.1-2.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.6.1-2.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1af1a6547f8eb03e45b86224f5c223f7e31a9ba05aa4689945c2d3cd5db01694
+size 635563857

--- a/dangerzone/f40/dangerzone-0.6.1-2.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.6.1-2.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32c31bf0de7aa06970079fdd0cc6c44751e3989b9415a6d790ffc4fc43d95069
+size 632381175

--- a/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dd647521b5521c4842349eb4f75fb5fa6e302bb6add9b642a14d70cb9fe95028
-size 227208

--- a/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.6.1-1.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a1cd22b67ec4b4188b2a4472de93d058e3cb125b3d2e7a5d6751dd4cb29ab72
-size 214044

--- a/dangerzone/f40/dangerzone-qubes-0.6.1-2.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.6.1-2.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0bcec34034e13d62551cd286e999463adab0a12c4f2b2db31aa1371b74518d3
+size 154635

--- a/dangerzone/f40/dangerzone-qubes-0.6.1-2.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.6.1-2.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a492c686b361d29114a25f67350c233b2359367c5b6b72d7e129e74c9ee456dd
+size 214489

--- a/dangerzone/f40/python3-pyside6-6.6.3.1-1.fc40.src.rpm
+++ b/dangerzone/f40/python3-pyside6-6.6.3.1-1.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:314180fe2122233abb7931b5053a295f43b80c90024f76d60df8026c7aa6ac59
-size 207514270

--- a/dangerzone/f40/python3-pyside6-6.6.3.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/python3-pyside6-6.6.3.1-1.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e261c4d558e8c9e9bf0f9ac183230ee9d354456aa30d69081a582212d5ef8b3
-size 120529512

--- a/dangerzone/f40/python3-pyside6-6.7.1-1.fc40.src.rpm
+++ b/dangerzone/f40/python3-pyside6-6.7.1-1.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed8766c85e8849312a5ba62644ff9415c698d9123fd4c5caa829197e8a01fc8f
+size 224153337

--- a/dangerzone/f40/python3-pyside6-6.7.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/python3-pyside6-6.7.1-1.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:729205909f05118e27bb19c0d15d43d7e7672e3943e9906054e6f39ea536f96f
+size 133492688


### PR DESCRIPTION
Add PySide6 RPMs created from the `freedomofpress/maint-dangerzone-pyside6` repo, based on 6.7.1, and remove the previous 6.6.3.1 packages. We have decided to package PySide6 6.7.1, since a recent Python3 update lead to a segfault in our PySide6 package (see freedomofpress/dangerzone#801).

Also, in this PR we include new Dangerzone RPMs, built from https://github.com/freedomofpress/dangerzone/pull/819 , to fix an issue with incorrect file permissions (see freedomofpress/dangerzone#727).


