### PR TITLE
Add Dangerzone 0.7.1 packages for Fedora 41

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -28,6 +28,7 @@ jobs:
         include:
           - version: "39"
           - version: "40"
+          - version: "41"
     steps:
       - name: Checkout dangerzone repo
         uses: actions/checkout@v4

--- a/dangerzone/f41/dangerzone-0.7.1-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-0.7.1-1.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a559809ab57f26d0501f44600b898de2e2e2adc6d39174e5e76392ad31498f1
+size 690371043

--- a/dangerzone/f41/dangerzone-0.7.1-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-0.7.1-1.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a07b3dcdf2f74d37e3baa4e26f114f5f2ac80c14ab53b682449d925a81204e4
+size 687301332

--- a/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e346373c11ecec24058f3b71d82547767a21e607c8908f4e6d975afa075b32
+size 165852

--- a/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:712f0f021e75fcb4e1509dd8e87f2ef6fc0a1c18bcb03bcd51eb9ef59b0f9fdd
+size 229465


### PR DESCRIPTION
Build and publish Dangerzone 0.7.1 packages for the upcoming Fedora 41 release.