### PR TITLE
Add packages for Dangezone 0.8.0

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: main
         run: |
           ./dev_scripts/env.py --distro fedora --version ${{ matrix.version }} \
-              run dangerzone-cli dangerzone/tests/test_docs/sample-pdf.pdf
+              run dangerzone-cli dangerzone/tests/test_docs/sample-pdf.pdf --ocr-lang eng
 
       - name: Check that the Dangerzone GUI imports work
         working-directory: main

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: "39"
           - version: "40"
           - version: "41"
     steps:

--- a/dangerzone/f39/dangerzone-0.7.0-2.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-0.7.0-2.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f66e61783072fad492d36e5dccf85f4a020383052f7383ad5f5b5110e5523ffb
-size 692623867

--- a/dangerzone/f39/dangerzone-0.7.0-2.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-0.7.0-2.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e4ed30999a37c6e4f5a2107c5acb143ab9a2e9803e80d50fea8c6fb8ca7db34
-size 689417806

--- a/dangerzone/f39/dangerzone-0.7.1-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-0.7.1-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f63d3fdb6e5b7c7b35438d67566ff7745ab6bb38426661deeb6923a756361134
-size 690443554

--- a/dangerzone/f39/dangerzone-0.7.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-0.7.1-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df4331dcbae9a01fd99fd079aba7e2b505a70a233a646d4772d67d2f3672f826
-size 687238375

--- a/dangerzone/f39/dangerzone-qubes-0.7.1-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.7.1-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2806f63dbf28baacdb0abae114d91e8ff66db69814d67ea087e09dc1f00d4e1
-size 235627

--- a/dangerzone/f39/dangerzone-qubes-0.7.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.7.1-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1f2a208487892510a41ef7971e4d9f76f9951e6b5f4009dbec7aff6a7e9e3c7
-size 227851

--- a/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.src.rpm
+++ b/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:85792245e5b648078915544f61cbd35764b5f4c41bee9603ba2400f0753c8534
-size 224162989

--- a/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65f6a4874df15b8b592ef4c61934a9ae4aab6de863c00dc7d39cae02f8ba7710
-size 133492668

--- a/dangerzone/f40/dangerzone-0.7.0-2.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.7.0-2.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:353204f0ef1f65afc1fa6528deb04b2c264bb704f2c07a953d435c45abf407be
-size 692616376

--- a/dangerzone/f40/dangerzone-0.7.0-2.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.7.0-2.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3b6962d62c989ae21e8310d379c85c4c2b70f4a9e405ffa6d7ab29f674681ca2
-size 689416030

--- a/dangerzone/f40/dangerzone-0.7.1-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.7.1-1.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe39a77409b8fd30fa50c9f7dae904631fcb6acf584a49d2d228eb884d9dfcc5
-size 690441226

--- a/dangerzone/f40/dangerzone-0.7.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.7.1-1.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47f689a7f9113c259225acba6067e1d9e6c03eb3bd016caac98676a832a8a5de
-size 687239286

--- a/dangerzone/f40/dangerzone-0.8.0-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.8.0-1.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:948353253b846598814ec0a2dbce4a8f2aa59f575a6e2dadf2630101007b4d85
+size 520850688

--- a/dangerzone/f40/dangerzone-0.8.0-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.8.0-1.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:872a05949bc7c1d4025fd24d87f1b77f90f63e9d06f4de163328303ab64ce102
+size 518322365

--- a/dangerzone/f40/dangerzone-qubes-0.7.1-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.7.1-1.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfd8cac44d72ccadb4877277e7b7a2ef8c3ac36280f6ab9ce5f32557b3d21d2f
-size 235474

--- a/dangerzone/f40/dangerzone-qubes-0.7.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.7.1-1.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d9bea708edabf0ac268cedb46f7e05d753d1c15d01620a880eb0e0608f3669e
-size 227879

--- a/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bd6e53c25b1df2bfc05f69203898a11f29da28697ff01020cb0be7ee0ec65d5
+size 163632

--- a/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3aef76c5f57ea7aee80f35e9a9d7a04dcf87094b7ef899e17110a8c7a707592
+size 225916

--- a/dangerzone/f41/dangerzone-0.7.1-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-0.7.1-1.fc41.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a559809ab57f26d0501f44600b898de2e2e2adc6d39174e5e76392ad31498f1
-size 690371043

--- a/dangerzone/f41/dangerzone-0.7.1-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-0.7.1-1.fc41.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a07b3dcdf2f74d37e3baa4e26f114f5f2ac80c14ab53b682449d925a81204e4
-size 687301332

--- a/dangerzone/f41/dangerzone-0.8.0-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-0.8.0-1.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23213452d6224835ec225ac58da58c5804ecc15d8c40e68bb454e3bdc1da58e3
+size 520851257

--- a/dangerzone/f41/dangerzone-0.8.0-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-0.8.0-1.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bd96e22ba465553d1df4444afc7aacfa5a45ad8532dd81a1d7dfb2db4e3975a
+size 518320471

--- a/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02e346373c11ecec24058f3b71d82547767a21e607c8908f4e6d975afa075b32
-size 165852

--- a/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.7.1-1.fc41.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:712f0f021e75fcb4e1509dd8e87f2ef6fc0a1c18bcb03bcd51eb9ef59b0f9fdd
-size 229465

--- a/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8dcb05726ec2f2055eab44d6c75fb7eca81ae117a475c14f43dffc56383f91b
+size 164335

--- a/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:741cde1ff558418d15be13b77adccb1907aff9ca029e8127ed8ea16cd436cc70
+size 228537


### PR DESCRIPTION
Add packages for the latest Dangerzone release (0.8.0), and prune older ones. As for Fedora 39, we remove it from our distro and CI checks, since it's now EOL.