### PR TITLE
Add packages for Fedora 39

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - version: "39"
           - version: "40"
           - version: "41"
     steps:

--- a/dangerzone/f39/dangerzone-0.8.0-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-0.8.0-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b015b5df2273e337e635036e9d5b5b01a5070529d2337ec732a30221ab086e92
+size 520852857

--- a/dangerzone/f39/dangerzone-0.8.0-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-0.8.0-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a191a0dad45aa8619f06a98ffdd0571515c3744225ea00934a1ad94c9dd8d12
+size 518322232

--- a/dangerzone/f39/dangerzone-qubes-0.8.0-1.fc39.src.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.8.0-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e5ba3249802bbe1bfc2d07ffd32ba8ef26889bbe1fd0cb97e975d5057ab41dc
+size 163490

--- a/dangerzone/f39/dangerzone-qubes-0.8.0-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/dangerzone-qubes-0.8.0-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89c2849304a6f03aa8847e5a32d79b5d96d8665de7054f9ccb2ecae0ed2c226a
+size 225898

--- a/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.src.rpm
+++ b/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85792245e5b648078915544f61cbd35764b5f4c41bee9603ba2400f0753c8534
+size 224162989

--- a/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.x86_64.rpm
+++ b/dangerzone/f39/python3-pyside6-6.7.1-1.fc39.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65f6a4874df15b8b592ef4c61934a9ae4aab6de863c00dc7d39cae02f8ba7710
+size 133492668


### PR DESCRIPTION
Add a Dangerzone 0.8.0 package, since Fedora 39 is not EOL yet [1], as we mistakenly assumed.

[1] https://fedorapeople.org/groups/schedule/f-39/f-39-key-tasks.html