### PR TITLE
Update packages to 0.8.1-2

### DIFF
--- a/dangerzone/f40/dangerzone-0.8.1-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.8.1-1.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e03f61ac264d12f567fb8350c7502ec0871b93018f04d8d6827010e088a93dc5
-size 601483880

--- a/dangerzone/f40/dangerzone-0.8.1-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.8.1-1.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0e7fa7c6e9cbbfd6cdab7cbb1b8b24ffc64ec4be03337a4741687bf6ef3b510
-size 598461683

--- a/dangerzone/f40/dangerzone-0.8.1-2.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.8.1-2.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83632dc03988f292eb292c9508f2c4854f1610d5993d7b7c87c1f4dfd3efffc0
+size 601481829

--- a/dangerzone/f40/dangerzone-0.8.1-2.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.8.1-2.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e27e819a4e6e4882a64ea7297b09e0e92ed56833b830b2d2f5910fc51bcebc53
+size 598462058

--- a/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8bd6e53c25b1df2bfc05f69203898a11f29da28697ff01020cb0be7ee0ec65d5
-size 163632

--- a/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.0-1.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3aef76c5f57ea7aee80f35e9a9d7a04dcf87094b7ef899e17110a8c7a707592
-size 225916

--- a/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ebb546886265adb9d45f7e9addc6ed2f5f288ad2f40999227135ef689dd082a
+size 161325

--- a/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9db70230e18a3775bdd087fef8fd5520e6b4958045221fcd11cc3e705b792b9f
+size 225872

--- a/dangerzone/f41/dangerzone-0.8.1-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-0.8.1-1.fc41.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc6f2d3b7aa933b4f4ba696ccc778b97a50a63f19878161b88ec4e143221bc1a
-size 601484449

--- a/dangerzone/f41/dangerzone-0.8.1-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-0.8.1-1.fc41.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39161fc5d3cb5cc39c6a8c296578dcb6f8ba1b5a0567646919f39cd7cc59bfab
-size 598462410

--- a/dangerzone/f41/dangerzone-0.8.1-2.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-0.8.1-2.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33c8d8811a061c2aedd6072292752e2e0bcb0a529e39969953f451915b2f0362
+size 601482359

--- a/dangerzone/f41/dangerzone-0.8.1-2.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-0.8.1-2.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc129f249853e9a37571c66aa58739ad67bed7b870eff9b55b3c86dff1498997
+size 598463578

--- a/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8dcb05726ec2f2055eab44d6c75fb7eca81ae117a475c14f43dffc56383f91b
-size 164335

--- a/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.0-1.fc41.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:741cde1ff558418d15be13b77adccb1907aff9ca029e8127ed8ea16cd436cc70
-size 228537

--- a/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5fc802033aa70fdeb7f799415116c1b45babe91be12bd67fab729fe6629f42f
+size 161989

--- a/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fd38a067e9cef2d7f48be627551021fe10037409239f87854302a32c137aa13
+size 228498


### PR DESCRIPTION
Update packages to version 0.8.1-2, including the Qubes ones. The reason for the update is a stale Shiboken6 version pin, which we want to remove.

Refs freedomofpress/dangerzone#1083