### PR TITLE
Add Dangerzone 0.9.0 packages

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -28,6 +28,7 @@ jobs:
         include:
           - version: "40"
           - version: "41"
+          - version: "42"
     steps:
       - name: Checkout dangerzone repo
         uses: actions/checkout@v4

--- a/dangerzone/f40/dangerzone-0.8.1-2.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.8.1-2.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:83632dc03988f292eb292c9508f2c4854f1610d5993d7b7c87c1f4dfd3efffc0
-size 601481829

--- a/dangerzone/f40/dangerzone-0.8.1-2.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.8.1-2.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e27e819a4e6e4882a64ea7297b09e0e92ed56833b830b2d2f5910fc51bcebc53
-size 598462058

--- a/dangerzone/f40/dangerzone-0.9.0-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-0.9.0-1.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:252bf50291a37f8462169c476f782cef9accc4f47d68d8bd9c679ed4e74e1e7a
+size 476360752

--- a/dangerzone/f40/dangerzone-0.9.0-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-0.9.0-1.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17adb5221da0f695d71a1cb798fca88f2622f3c7d5db8e833eee7d0dac77b5fc
+size 474865601

--- a/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ebb546886265adb9d45f7e9addc6ed2f5f288ad2f40999227135ef689dd082a
-size 161325

--- a/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.8.1-2.fc40.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9db70230e18a3775bdd087fef8fd5520e6b4958045221fcd11cc3e705b792b9f
-size 225872

--- a/dangerzone/f40/dangerzone-qubes-0.9.0-1.fc40.src.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.9.0-1.fc40.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d338acc3aa1e7769a07dc57c6ed74fecba5edb42b646e3f18abe657f57b33ae7
+size 167607

--- a/dangerzone/f40/dangerzone-qubes-0.9.0-1.fc40.x86_64.rpm
+++ b/dangerzone/f40/dangerzone-qubes-0.9.0-1.fc40.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a186dca1c808439de8313c6cefff6bd230d5b8df57f0af83ede0152fe6260ec9
+size 235280

--- a/dangerzone/f41/dangerzone-0.8.1-2.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-0.8.1-2.fc41.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33c8d8811a061c2aedd6072292752e2e0bcb0a529e39969953f451915b2f0362
-size 601482359

--- a/dangerzone/f41/dangerzone-0.8.1-2.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-0.8.1-2.fc41.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc129f249853e9a37571c66aa58739ad67bed7b870eff9b55b3c86dff1498997
-size 598463578

--- a/dangerzone/f41/dangerzone-0.9.0-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-0.9.0-1.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7b7ed66d9ee870249154e8140130402ab19705053c319dadbab848abd03b2fb
+size 476361282

--- a/dangerzone/f41/dangerzone-0.9.0-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-0.9.0-1.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2398199114d32fc2ceda15fd1bcc80a337318f71cc0b4a3342cc0780b8f251b
+size 474867728

--- a/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.src.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5fc802033aa70fdeb7f799415116c1b45babe91be12bd67fab729fe6629f42f
-size 161989

--- a/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.8.1-2.fc41.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fd38a067e9cef2d7f48be627551021fe10037409239f87854302a32c137aa13
-size 228498

--- a/dangerzone/f41/dangerzone-qubes-0.9.0-1.fc41.src.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.9.0-1.fc41.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a98c7ea6fed7a6b766cd01db7a0940e8adbe6bdcb44958c5bf43eefe012bc2eb
+size 168271

--- a/dangerzone/f41/dangerzone-qubes-0.9.0-1.fc41.x86_64.rpm
+++ b/dangerzone/f41/dangerzone-qubes-0.9.0-1.fc41.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5e1efb75967022ca9e1d25a83e4f1421cf1c77ff7268a6ff820ebbae641ed15
+size 237933

--- a/dangerzone/f42/dangerzone-0.9.0-1.fc42.src.rpm
+++ b/dangerzone/f42/dangerzone-0.9.0-1.fc42.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6c3f28cad6a79386f604d661d39ea855f7f5f0f10ea3900d37015dba76335b0
+size 476361282

--- a/dangerzone/f42/dangerzone-0.9.0-1.fc42.x86_64.rpm
+++ b/dangerzone/f42/dangerzone-0.9.0-1.fc42.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6095e59e6630673483ba3b0763438c11bcaac3afdc76b9a23c2f476b63d7924
+size 474869322

--- a/dangerzone/f42/dangerzone-qubes-0.9.0-1.fc42.src.rpm
+++ b/dangerzone/f42/dangerzone-qubes-0.9.0-1.fc42.src.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d406b9debf4fba7b2f51f103a22c0c6f5c465547ba65f250c1795ef40b2fe86
+size 168271

--- a/dangerzone/f42/dangerzone-qubes-0.9.0-1.fc42.x86_64.rpm
+++ b/dangerzone/f42/dangerzone-qubes-0.9.0-1.fc42.x86_64.rpm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:030e82dc551c4b79007083bfafd304e0a2130bbd9b6902034a082f014bef01cc
+size 238110


### PR DESCRIPTION
This PR makes the following changes:
* Drops the older Dangerzone 0.8.1 packages and adds the new 0.9.0 ones.
* Adds packages for Fedora 42.