### PR TITLE
ci: Put colons in quotations

### DIFF
--- a/.github/workflows/check-packages-apt-dangerzone.yml
+++ b/.github/workflows/check-packages-apt-dangerzone.yml
@@ -1,4 +1,4 @@
-name: APT: Check Dangerzone packages
+name: "APT: Check Dangerzone packages"
 
 on:
   pull_request:

--- a/.github/workflows/check-packages-yum-dangerzone.yml
+++ b/.github/workflows/check-packages-yum-dangerzone.yml
@@ -1,4 +1,4 @@
-name: YUM: Check Dangerzone packages
+name: "YUM: Check Dangerzone packages"
 
 on:
   pull_request:


### PR DESCRIPTION
We need to put colons after YAML keys in quotations, else the GitHub parser for the workflow throws an error.