### PR TITLE
ci: Add workflow files in paths that trigger them

### DIFF
--- a/.github/workflows/publish-apt.yml
+++ b/.github/workflows/publish-apt.yml
@@ -7,6 +7,8 @@ on:
       - release
     paths:
       - 'apt-tools-prod/repo/public/**'
+      - '.github/workflows/publish-apt.yml'
+      - '.github/workflows/r2.yml'
 
 jobs:
   publish-yum:

--- a/.github/workflows/publish-landing.yml
+++ b/.github/workflows/publish-landing.yml
@@ -1,5 +1,5 @@
 name: Publish landing page to R2
-# Trigger on pushes to main/release that modify public/
+# Trigger on pushes to main/release that modify templates/landing/
 on:
   push:
     branches:
@@ -7,6 +7,8 @@ on:
       - release
     paths:
       - 'templates/landing/**'
+      - '.github/workflows/publish-landing.yml'
+      - '.github/workflows/r2.yml'
 
 jobs:
   publish-yum:

--- a/.github/workflows/publish-yum.yml
+++ b/.github/workflows/publish-yum.yml
@@ -7,6 +7,8 @@ on:
       - release
     paths:
       - 'yum-tools-prod/public/**'
+      - '.github/workflows/publish-yum.yml'
+      - '.github/workflows/r2.yml'
 
 jobs:
   publish-yum:


### PR DESCRIPTION
Add the workflow files themselves within the 'paths:' field of the workflows. This way, the workflows will be triggered either when there's a change to the public-facing repo, or a change to the workflow file itself. We are making sure that the push action is idempotent, so a double push is not be an issue.

(The exact same pull request (https://github.com/freedomofpress/packages/pull/48) erroneously targeted `main` before, so this one syncs the `release` branch as well)